### PR TITLE
Added len method that returns the number of tokens in the vocabulary

### DIFF
--- a/knowledge/docling/utils/tokenizer.py
+++ b/knowledge/docling/utils/tokenizer.py
@@ -48,3 +48,7 @@ class OpenAITokenizerWrapper(PreTrainedTokenizerBase):
     def from_pretrained(cls, *args, **kwargs):
         """Class method to match HuggingFace's interface."""
         return cls()
+
+    def __len__(self) -> int:
+        """Return the size of the vocabulary."""
+        return self.vocab_size


### PR DESCRIPTION
Added this method, because it gives this NotImplementedError instead

/usr/local/lib/python3.11/dist-packages/docling_core/transforms/chunker/hybrid_chunker.py in _patch(cls, data)
     71     @classmethod
     72     def _patch(cls, data: Any) -> Any:
---> 73         if isinstance(data, dict) and (tokenizer := data.get("tokenizer")):
     74             max_tokens = data.get("max_tokens")
     75             if isinstance(tokenizer, BaseTokenizer):
/usr/local/lib/python3.11/dist-packages/transformers/tokenization_utils_base.py in __len__(self)
   1511 
   1512     def __len__(self) -> int:
-> 1513         raise NotImplementedError()
   1514 
   1515     def get_vocab(self) -> Dict[str, int]:
NotImplementedError: